### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/UnoSite/PushToUptimeKuma/security/code-scanning/9](https://github.com/UnoSite/PushToUptimeKuma/security/code-scanning/9)

To fix the problem, add a `permissions` block to limit the `GITHUB_TOKEN` access for the job(s) in the workflow. Because the job pushes a commit (requires `contents: write`) and uploads a release asset (requires `contents: write`), the job must have at least `contents: write` permission. The most appropriate way is to explicitly set:

```yaml
permissions:
  contents: write
```

This can be added either at the root of the workflow (recommended, as there is only one job), or at the job level under `release_zip_file`. In this case, let's apply it at the root, immediately after the workflow `name` to cover all jobs (present and future). No functionality will be lost, and the permissions used are minimal for the job's needs. No external methods, imports, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
